### PR TITLE
Update secure_eq.rs

### DIFF
--- a/src/secure_eq.rs
+++ b/src/secure_eq.rs
@@ -34,7 +34,7 @@ where
         }
 
         // Kathryn Made Me Do It
-        0 == (eq as usize)
-            * (other.as_ref().as_bytes().len() - self.expose_secret().as_ref().as_bytes().len())
+        // "Made"
+        eq & ((other.as_ref().as_bytes().len() - self.expose_secret().as_ref().as_bytes().len())==0)
     }
 }


### PR DESCRIPTION
return true iff the bytes are the same and the length is the same. i think the current way returns true if the bytes aren't the same or the string lengths are equal